### PR TITLE
Feature/prevent crashes for new users

### DIFF
--- a/pkg/aws/sso.go
+++ b/pkg/aws/sso.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,7 +40,7 @@ func GenerateConfig(ssoURL, region string, overwrite bool) error {
 		if err != nil {
 			return err
 		}
-		configPath := homeDir + "/.aws/config"
+		configPath := filepath.Join(homeDir, ".aws", "config")
 		err = os.Remove(configPath)
 		if err != nil && !os.IsNotExist(err) {
 			return err

--- a/pkg/aws/sso.go
+++ b/pkg/aws/sso.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
@@ -11,10 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 	ssoOidcTypes "github.com/aws/aws-sdk-go-v2/service/ssooidc/types"
 	"github.com/skratchdot/open-golang/open"
-	"log"
-	"os"
-	"strings"
-	"time"
 )
 
 func GenerateConfig(ssoURL, region string, overwrite bool) error {
@@ -40,8 +41,8 @@ func GenerateConfig(ssoURL, region string, overwrite bool) error {
 		}
 		configPath := homeDir + "/.aws/config"
 		err = os.Remove(configPath)
-		if err != nil {
-			fmt.Println("File not found. Continue...", err)
+		if err != nil && !os.IsNotExist(err) {
+			return err
 		}
 		for _, acc := range accounts {
 			roles := GetRolesByAccount(ctx, client, acc, token.AccessToken)

--- a/pkg/commands/generate.go
+++ b/pkg/commands/generate.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/Gympass/aws-vault-scg/pkg/aws"
 	"github.com/urfave/cli/v2"
@@ -32,31 +33,65 @@ var Generate = &cli.Command{
 			region = "us-east-1"
 		}
 
-		var o string
-		fmt.Print("Overwrite current config(~/.aws/config)[y/N]? ")
-		_, err := fmt.Scanf("%s", &o)
-		if err != nil {
-			fmt.Println("Default option")
-		}
-		switch {
-		case o == "y" || o == "Y":
-			err := aws.GenerateConfig(ssoURL, region, true)
+		configDir := configDirName()
+
+		if !fileExists(configDir + "/config") {
+			// no config file, make sure path exists
+			createPath(configDir)
+			generateConfig(ssoURL, region)
+		} else {
+			// config already exists, check if the user wants to overwrite
+			var selectedOption string
+			fmt.Print("Overwrite current config(~/.aws/config)[y/N]? ")
+			_, err := fmt.Scanf("%s", &selectedOption)
 			if err != nil {
-				log.Fatalf("Error to generate config file: %v", err)
+				fmt.Println("Default option")
 			}
-		case o == "n" || o == "N":
-			err := aws.GenerateConfig(ssoURL, region, false)
-			fmt.Println("You can use this profile values to update your config file(~/.aws/config)")
-			if err != nil {
-				log.Fatalf("Error to print config: %v", err)
-			}
-		default:
-			err := aws.GenerateConfig(ssoURL, region, false)
-			fmt.Println("You can use this profile values to update your config file(~/.aws/config)")
-			if err != nil {
-				log.Fatalf("Error to print config: %v", err)
+
+			if selectedOption == "y" || selectedOption == "Y" {
+				generateConfig(ssoURL, region)
+			} else {
+				printConfig(ssoURL, region)
 			}
 		}
+
 		return nil
 	},
+}
+
+func configDirName() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("Error identifying the home dir: %v", err)
+	}
+	return homeDir + "/.aws"
+}
+
+func fileExists(fileName string) bool {
+	if _, err := os.Stat(fileName); err == nil {
+		return true
+	} else {
+		return false
+	}
+}
+
+func createPath(path string) {
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		log.Fatalf("Error creating %v: %v", path, err)
+	}
+}
+
+func generateConfig(ssoURL string, region string) {
+	err := aws.GenerateConfig(ssoURL, region, true)
+	if err != nil {
+		log.Fatalf("Error to generate config file: %v", err)
+	}
+}
+
+func printConfig(ssoURL string, region string) {
+	err := aws.GenerateConfig(ssoURL, region, false)
+	fmt.Println("You can use this profile values to update your config file(~/.aws/config)")
+	if err != nil {
+		log.Fatalf("Error to print config: %v", err)
+	}
 }

--- a/pkg/commands/generate.go
+++ b/pkg/commands/generate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/Gympass/aws-vault-scg/pkg/aws"
 	"github.com/urfave/cli/v2"
@@ -34,8 +35,9 @@ var Generate = &cli.Command{
 		}
 
 		configDir := configDirName()
+		configFile := filepath.Join(configDir, "config")
 
-		if !fileExists(configDir + "/config") {
+		if !fileExists(configFile) {
 			// no config file, make sure path exists
 			createPath(configDir)
 			generateConfig(ssoURL, region)
@@ -64,7 +66,7 @@ func configDirName() string {
 	if err != nil {
 		log.Fatalf("Error identifying the home dir: %v", err)
 	}
-	return homeDir + "/.aws"
+	return filepath.Join(homeDir, ".aws")
 }
 
 func fileExists(fileName string) bool {


### PR DESCRIPTION
If the directory ~/.aws didn't exist the process was crashing.
Added a check if the file exists, which creates the directory ~/.aws if it doesn't exist.

Closes #2 