### PR TITLE
fix(sso): Increase number of retrieved profiles

### DIFF
--- a/pkg/aws/sso.go
+++ b/pkg/aws/sso.go
@@ -178,7 +178,7 @@ func ListAccounts(ctx context.Context, client *sso.Client, token *string) []type
 		accounts  []types.AccountInfo
 	)
 	for {
-		acc, err := client.ListAccounts(ctx, &sso.ListAccountsInput{AccessToken: token, NextToken: nextToken, MaxResults: aws.Int32(50)})
+		acc, err := client.ListAccounts(ctx, &sso.ListAccountsInput{AccessToken: token, NextToken: nextToken, MaxResults: aws.Int32(200)})
 		if err != nil {
 			log.Fatalf("unable to list accounts, %v", err)
 		}


### PR DESCRIPTION
Due to the increasing amount of AWS accounts, only 50 profiles are not sufficient to accommodate all permission sets.

This PR increases the number of retrieved profiles.